### PR TITLE
Add PowerPoint customization prototype

### DIFF
--- a/prototype/powerpoint-customizer/README.md
+++ b/prototype/powerpoint-customizer/README.md
@@ -1,0 +1,36 @@
+# PowerPoint Customizer Prototype
+
+This prototype demonstrates automating PowerPoint text customization using OpenRouter's generative AI.
+It exposes a small FastAPI server and a minimal React front‑end.
+
+## Features
+
+- Upload a PowerPoint template (`.pptx`)
+- Provide contextual text for the AI
+- Preview AI‑generated slide text before downloading
+- Download the customized presentation
+
+## Requirements
+
+- Python 3.10+
+- Node.js (for the optional front‑end)
+- An OpenRouter API key
+
+Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Start the server:
+
+```bash
+export OPEN_ROUTER_API_KEY=your_key_here
+uvicorn server:app --reload
+```
+
+Then open `frontend/index.html` in a browser.
+
+## Notes
+
+This is a very small prototype and only customizes slide text. It does not yet store templates or maintain history. The AI requests are synchronous and may be slow on large presentations.

--- a/prototype/powerpoint-customizer/frontend/index.html
+++ b/prototype/powerpoint-customizer/frontend/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PPTX Customizer</title>
+    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+function App() {
+  const [file, setFile] = React.useState(null);
+  const [context, setContext] = React.useState('');
+  const [preview, setPreview] = React.useState([]);
+
+  const handlePreview = async () => {
+    if (!file) return;
+    const form = new FormData();
+    form.append('pptx_file', file);
+    form.append('context', context);
+    const res = await fetch('/preview', { method: 'POST', body: form });
+    const data = await res.json();
+    setPreview(data);
+  };
+
+  const handleDownload = async () => {
+    if (!file) return;
+    const form = new FormData();
+    form.append('pptx_file', file);
+    form.append('context', context);
+    const res = await fetch('/apply', { method: 'POST', body: form });
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'customized.pptx';
+    a.click();
+  };
+
+  return (
+    <div style={{padding:'20px', fontFamily:'sans-serif'}}>
+      <h2>PPTX Customizer</h2>
+      <input type="file" accept=".pptx" onChange={e => setFile(e.target.files[0])} />
+      <br/>
+      <textarea placeholder="Context" value={context} onChange={e => setContext(e.target.value)} rows="4" cols="50"></textarea>
+      <br/>
+      <button onClick={handlePreview}>Preview</button>
+      <button onClick={handleDownload}>Download</button>
+
+      <ul>
+        {preview.map((item, idx) => (
+          <li key={idx}>
+            <strong>Slide {item.slide} shape {item.shape}</strong>
+            <div>Original: {item.original}</div>
+            <div>Generated: {item.generated}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+ReactDOM.render(<App />, document.getElementById('root'));
+</script>
+</body>
+</html>

--- a/prototype/powerpoint-customizer/requirements.txt
+++ b/prototype/powerpoint-customizer/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+python-pptx
+requests
+python-multipart

--- a/prototype/powerpoint-customizer/server.py
+++ b/prototype/powerpoint-customizer/server.py
@@ -1,0 +1,84 @@
+from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.responses import StreamingResponse, JSONResponse
+from pptx import Presentation
+import io
+import os
+import requests
+
+app = FastAPI(title="PowerPoint Customizer")
+
+OPEN_ROUTER_API_KEY = os.getenv("OPEN_ROUTER_API_KEY")
+OPEN_ROUTER_MODEL = os.getenv("OPEN_ROUTER_MODEL", "mistralai/mistral-7b-instruct")
+
+
+def call_openrouter(original_text: str, context: str) -> str:
+    """Send text to OpenRouter and return the generated result."""
+    if not OPEN_ROUTER_API_KEY:
+        return original_text  # no API key provided, return original
+
+    payload = {
+        "model": OPEN_ROUTER_MODEL,
+        "messages": [
+            {"role": "system", "content": f"Use this context to customize the presentation: {context}"},
+            {"role": "user", "content": original_text},
+        ],
+    }
+    headers = {
+        "Authorization": f"Bearer {OPEN_ROUTER_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    try:
+        resp = requests.post(
+            "https://openrouter.ai/api/v1/chat/completions",
+            json=payload,
+            headers=headers,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data["choices"][0]["message"]["content"]
+    except Exception:
+        return original_text
+
+
+def generate_customized_pptx(prs: Presentation, context: str) -> Presentation:
+    for slide in prs.slides:
+        for shape in slide.shapes:
+            if shape.has_text_frame:
+                updated_text = call_openrouter(shape.text, context)
+                shape.text = updated_text
+    return prs
+
+
+@app.post("/preview")
+async def preview_presentation(pptx_file: UploadFile = File(...), context: str = Form(...)):
+    contents = await pptx_file.read()
+    prs = Presentation(io.BytesIO(contents))
+    preview = []
+    for slide_idx, slide in enumerate(prs.slides):
+        for shape_idx, shape in enumerate(slide.shapes):
+            if shape.has_text_frame:
+                new_text = call_openrouter(shape.text, context)
+                preview.append({
+                    "slide": slide_idx,
+                    "shape": shape_idx,
+                    "original": shape.text,
+                    "generated": new_text,
+                })
+    return JSONResponse(preview)
+
+
+@app.post("/apply")
+async def apply_changes(pptx_file: UploadFile = File(...), context: str = Form(...)):
+    contents = await pptx_file.read()
+    prs = Presentation(io.BytesIO(contents))
+    prs = generate_customized_pptx(prs, context)
+    output = io.BytesIO()
+    prs.save(output)
+    output.seek(0)
+    return StreamingResponse(
+        output,
+        media_type="application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        headers={"Content-Disposition": "attachment; filename=customized.pptx"},
+    )
+


### PR DESCRIPTION
## Summary
- create a `powerpoint-customizer` prototype using FastAPI
- add simple React front-end for uploading a PPTX and viewing text updates
- document how to run the prototype

## Testing
- `pip install -r prototype/powerpoint-customizer/requirements.txt`
- `uvicorn prototype.powerpoint-customizer.server:app --port 8000` *(works)*
- `npm test` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_6849f4ae02608329b63dbd7baf39fc76